### PR TITLE
replace reference to constants.js with process.env.boardId

### DIFF
--- a/pages/api/createStickyNote.js
+++ b/pages/api/createStickyNote.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { board_id } from "../../constants";
 
 export default function handler(req, res) {
   const headers = {
@@ -19,7 +18,7 @@ export default function handler(req, res) {
   };
 
   axios
-    .post(`https://api.miro.com/v2/boards/${board_id}/sticky_notes`, data, {
+    .post(`https://api.miro.com/v2/boards/${process.env.boardId}/sticky_notes`, data, {
       headers: headers,
     })
     .then(function (response) {

--- a/pages/api/getItems.js
+++ b/pages/api/getItems.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { board_id } from "../../constants";
 
 export default function handler(req, res) {
   const headers = {
@@ -10,7 +9,7 @@ export default function handler(req, res) {
 
   axios
     .get(
-      `https://api.miro.com/v2/boards/${board_id}/items?limit=50&type=sticky_note&type=shape&type=text`,
+      `https://api.miro.com/v2/boards/${process.env.boardId}/items?limit=50&type=sticky_note&type=shape&type=text`,
       {
         headers: headers,
       }

--- a/pages/api/updateContent.js
+++ b/pages/api/updateContent.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { board_id } from "../../constants";
 
 export default function handler(req, res) {
   const body = JSON.parse(req.body);
@@ -16,7 +15,7 @@ export default function handler(req, res) {
 
   axios
     .patch(
-      `https://api.miro.com/v2/boards/${board_id}/${item_type}s/${item_id}`,
+      `https://api.miro.com/v2/boards/${process.env.boardId}/${item_type}s/${item_id}`,
       {
         data: { content: content },
       },


### PR DESCRIPTION
As we removed constants.js in favor of including boardId directly in .env, need to update the api routes that reference the constants.js file.